### PR TITLE
Make getRawSense() publicly useful

### DIFF
--- a/src/main/java/de/tudarmstadt/ukp/jwktl/api/entry/WiktionaryTranslation.java
+++ b/src/main/java/de/tudarmstadt/ukp/jwktl/api/entry/WiktionaryTranslation.java
@@ -36,7 +36,7 @@ public class WiktionaryTranslation implements IWiktionaryTranslation {
 	protected String translation;
 	protected String transliteration;
 	protected String additionalInformation;
-	protected transient String rawSense;
+	protected String rawSense;
 	
 	/** Creates a new, empty translation. */ 
 	public WiktionaryTranslation() {}


### PR DESCRIPTION
0a8c30b532d1f203c24e03f8a986ae6f05b5a0c6 added `IWiktionaryTranslation.getRawSense()` method, but its implementation uses `transient` variable and so isn't stored in the database. That's a pity because this data is very useful — it's much more concise explanation of the sense than `IWikitionarySense.getGloss()` provides.

This PR makes it serializable so that it is available to users of the library and not just its test suite.