### PR TITLE
Fix parsing of audio pronunciation with lang= tag

### DIFF
--- a/src/main/java/de/tudarmstadt/ukp/jwktl/parser/en/components/ENPronunciationHandler.java
+++ b/src/main/java/de/tudarmstadt/ukp/jwktl/parser/en/components/ENPronunciationHandler.java
@@ -37,7 +37,7 @@ public class ENPronunciationHandler extends ENBlockHandler {
 	
 	protected static final Pattern PRONUNCIATION_CONTEXT = Pattern.compile("\\{\\{(?:a|sense)\\|([^\\}\\|]+?)\\}\\}");
 	protected static final Pattern PRONUNCIATION = Pattern.compile("\\{\\{(?:IPA|SAMPA)\\|.+?\\}\\}");
-	protected static final Pattern PRONUNCIATION_AUDIO = Pattern.compile("\\{\\{audio\\|([^\\}\\|]+?)(?:\\|([^\\}\\|]+?))?\\}\\}");
+	protected static final Pattern PRONUNCIATION_AUDIO = Pattern.compile("\\{\\{audio\\|([^\\}\\|]+?)(?:\\|([^\\}\\|]+?)(?:\\|lang=[^\\}\\|]+)?)?\\}\\}");
 	protected static final Pattern PRONUNCIATION_RYHME = Pattern.compile("\\{\\{rhymes\\|([^\\}\\|]+?)\\}\\}");
 	
 	protected List<IPronunciation> pronunciations;

--- a/src/test/java/de/tudarmstadt/ukp/jwktl/parser/en/components/ENPronunciationHandlerTest.java
+++ b/src/test/java/de/tudarmstadt/ukp/jwktl/parser/en/components/ENPronunciationHandlerTest.java
@@ -126,8 +126,8 @@ public class ENPronunciationHandlerTest extends ENWiktionaryEntryParserTest {
 		w.processBody("* {{audio|en-uk-dictionary.ogg|Audio (UK)}}", null);
 
 		w.processBody("* {{IPA|/fɹiː/}}, {{SAMPA|/fri:/}}", null);
-		w.processBody("* {{audio|en-us-free.ogg|Audio (US)}}", null);
-		w.processBody("* {{audio|En-uk-free.ogg|Audio (UK)}}", null);
+		w.processBody("* {{audio|en-us-free.ogg|Audio (US)|lang=en}}", null);
+		w.processBody("* {{audio|En-uk-free.ogg|Audio (UK)|lang=en}}", null);
 		w.processBody("*: {{rhymes|iː}}", null);
 
 		w.processBody("* {{a|RP}} {{IPA|/dɒɡ/}}, {{SAMPA|/dQg/}}", null);


### PR DESCRIPTION
Make Wiktionary entries (e.g. "battle") contain audio pronunciation markup in this form:
```
* {{audio|en-us-battle.ogg|Audio (US)|lang=en}}
```
ENPronunciationHandler couldn't handle this form, it only recognized the simpler one without language tag:
```
* {{audio|en-us-battle.ogg|Audio (US)}}
```

This PR fixes the regex to recognize both.

BTW, I noticed that more pronunciation records are appended with `lang`, e.g. `{{IPA|/ˈbætəl/|lang=en}}`, but their regexes aren't affected and they ignore the language as well (although I imagine it might be useful). For that reason this PR doesn't capture the language either.