### PR TITLE
Fixed: Handle "ies" suffix when parsing verb

### DIFF
--- a/src/main/java/de/tudarmstadt/ukp/jwktl/parser/en/components/ENWordFormHandler.java
+++ b/src/main/java/de/tudarmstadt/ukp/jwktl/parser/en/components/ENWordFormHandler.java
@@ -68,7 +68,7 @@ public class ENWordFormHandler implements ITemplateHandler, IWordFormHandler {
 	}
 
 	protected void handleNounTemplate(final Template template) {
-		boolean hasPlural = false;
+		boolean hasPlural = false, addAll = false;
 		for (Entry<String, String> par : template.getNamedParams())
 			if (par.getKey().startsWith("pl")) {
 				wordForms.add(createPlural(null, par.getValue()));
@@ -84,6 +84,9 @@ public class ENWordFormHandler implements ITemplateHandler, IWordFormHandler {
 			String param1 = template.getNumberedParam(0);
 			if ("-".equals(param1))
 				wordForms.add(createPlural(null, null)); // uncountable
+			else
+			if ("~".equals(param1))
+				wordForms.add(createPlural(lemma, "s")); // countable and uncountable
 			else
 			if ("!".equals(param1))
 				logger.finer("Not attested word form: " + template); // not attested
@@ -111,7 +114,22 @@ public class ENWordFormHandler implements ITemplateHandler, IWordFormHandler {
 			if ("?".equals(param2))
 				wordForms.add(createPlural(lemma, param1)); // unknown
 			else
+			if ("ies".equals(param2))
 				wordForms.add(createPlural(null, param1 + param2)); // unknown
+			else
+				addAll = true;
+		}
+		if (addAll || template.getNumberedParamsCount() > 2) {
+			int len = template.getNumberedParamsCount();
+			for(int i = 0; i < len; i++) {
+				String param = template.getNumberedParam(i);
+				if (param == null || "~".equals(param))
+					continue;
+				if ("s".equals(param) || "es".equals(param))
+					wordForms.add(createPlural(lemma, param));
+				else
+					wordForms.add(createPlural(null, param));
+			}
 		}
 	}
 
@@ -156,6 +174,26 @@ public class ENWordFormHandler implements ITemplateHandler, IWordFormHandler {
 			wordForms.add(createFormPresentParticiple(lemma + "ing"));
 			wordForms.add(createFormSimplePast(lemma + "ed"));
 			wordForms.add(createFormPastParticiple(lemma + "ed"));
+		} else
+		if (template.getNumberedParamsCount() == 1) {
+			String param1 = template.getNumberedParam(0);
+			if ("d".equals(param1)) {
+				wordForms.add(createFormThirdPerson(lemma + "s"));
+				wordForms.add(createFormPresentParticiple(lemma + "ing"));
+				wordForms.add(createFormSimplePast(lemma + "d"));
+				wordForms.add(createFormPastParticiple(lemma + "d"));
+			} else
+			if ("es".equals(param1)) {
+				wordForms.add(createFormThirdPerson(lemma + "es"));
+				wordForms.add(createFormPresentParticiple(lemma + "ing"));
+				wordForms.add(createFormSimplePast(lemma + "ed"));
+				wordForms.add(createFormPastParticiple(lemma + "ed"));
+			} else {
+				wordForms.add(createFormThirdPerson(lemma + "s"));
+				wordForms.add(createFormPresentParticiple(param1 + "ing"));
+				wordForms.add(createFormSimplePast(param1 + "ed"));
+				wordForms.add(createFormPastParticiple(param1 + "ed"));
+			}
 		} else
 		if (template.getNumberedParamsCount() == 2) {
 			String param1 = template.getNumberedParam(0);
@@ -228,6 +266,20 @@ public class ENWordFormHandler implements ITemplateHandler, IWordFormHandler {
 			wordForms.add(createFormPresentParticiple(param2));
 			wordForms.add(createFormSimplePast(param3));
 			wordForms.add(createFormPastParticiple(param4));
+		}
+		for (Entry<String, String> par : template.getNamedParams()) {
+			if (par.getKey().startsWith("pres"))
+				wordForms.add(createFormPresentParticiple(par.getValue()));
+			else
+			if (par.getKey().equals("past2")) {
+				int len = template.getNumberedParamsCount();
+				if (len == 3) {
+					wordForms.add(createFormSimplePast(par.getValue()));
+					wordForms.add(createFormPastParticiple(par.getValue()));
+				} else {
+					wordForms.add(createFormSimplePast(par.getValue()));
+				}
+			}
 		}
 	}
 

--- a/src/main/java/de/tudarmstadt/ukp/jwktl/parser/en/components/ENWordFormHandler.java
+++ b/src/main/java/de/tudarmstadt/ukp/jwktl/parser/en/components/ENWordFormHandler.java
@@ -121,14 +121,20 @@ public class ENWordFormHandler implements ITemplateHandler, IWordFormHandler {
 		}
 		if (addAll || template.getNumberedParamsCount() > 2) {
 			int len = template.getNumberedParamsCount();
+			boolean inserted = false;
 			for(int i = 0; i < len; i++) {
 				String param = template.getNumberedParam(i);
 				if (param == null || "~".equals(param))
 					continue;
+
 				if ("s".equals(param) || "es".equals(param))
 					wordForms.add(createPlural(lemma, param));
 				else
+				if ("".equals(param)) {
+					if (!inserted) wordForms.add(createPlural(lemma, "s"));
+				} else
 					wordForms.add(createPlural(null, param));
+				inserted = true;
 			}
 		}
 	}
@@ -251,7 +257,10 @@ public class ENWordFormHandler implements ITemplateHandler, IWordFormHandler {
 				wordForms.add(createFormSimplePast(lemma + "d"));
 				wordForms.add(createFormPastParticiple(lemma + "d"));
 			} else {
-				wordForms.add(createFormThirdPerson(param1));
+				if ("".equals(param1))
+					wordForms.add(createFormThirdPerson(lemma + "s"));
+				else
+					wordForms.add(createFormThirdPerson(param1));
 				wordForms.add(createFormPresentParticiple(param2));
 				wordForms.add(createFormSimplePast(param3));
 				wordForms.add(createFormPastParticiple(param3));
@@ -311,7 +320,10 @@ public class ENWordFormHandler implements ITemplateHandler, IWordFormHandler {
 				logger.finer("Unknown word form: " + template); // unknown
 			else {
 				wordForms.add(createAdjectiveForm(lemma, GrammaticalDegree.POSITIVE));
-				wordForms.add(createAdjectiveForm(param1, GrammaticalDegree.COMPARATIVE));
+				if ("".equals(param1))
+					wordForms.add(createAdjectiveForm("more " + lemma, GrammaticalDegree.COMPARATIVE));
+				else
+					wordForms.add(createAdjectiveForm(param1, GrammaticalDegree.COMPARATIVE));
 				wordForms.add(createAdjectiveForm("most " + lemma, GrammaticalDegree.SUPERLATIVE));
 			}
 		} else

--- a/src/main/java/de/tudarmstadt/ukp/jwktl/parser/en/components/ENWordFormHandler.java
+++ b/src/main/java/de/tudarmstadt/ukp/jwktl/parser/en/components/ENWordFormHandler.java
@@ -166,6 +166,12 @@ public class ENWordFormHandler implements ITemplateHandler, IWordFormHandler {
 				wordForms.add(createFormSimplePast(param1 + "ed"));
 				wordForms.add(createFormPastParticiple(param1 + "ed"));
 			} else
+			if ("ies".equals(param2)) {
+				wordForms.add(createFormThirdPerson(param1 + "ies"));
+				wordForms.add(createFormPresentParticiple(lemma + "ing"));
+				wordForms.add(createFormSimplePast(param1 + "ied"));
+				wordForms.add(createFormPastParticiple(param1 + "ied"));
+			} else
 			if ("d".equals(param2)) {
 				wordForms.add(createFormThirdPerson(param1 + "s"));
 				wordForms.add(createFormPresentParticiple(param1 + "ing"));

--- a/src/main/java/de/tudarmstadt/ukp/jwktl/parser/en/components/ENWordFormHandler.java
+++ b/src/main/java/de/tudarmstadt/ukp/jwktl/parser/en/components/ENWordFormHandler.java
@@ -283,6 +283,11 @@ public class ENWordFormHandler implements ITemplateHandler, IWordFormHandler {
 		}
 	}
 
+	// remove the ending letter 'e' if exists
+	private String removeEndingE(String str) {
+		return str.endsWith("e") ? str.substring(0, str.length()-1) : str;
+	}
+
 	protected void handleAdjectiveTemplate(final Template template) {
 		// http://en.wiktionary.org/wiki/Template:en-adj
 		if (template.getNumberedParamsCount() == 0) {
@@ -294,8 +299,8 @@ public class ENWordFormHandler implements ITemplateHandler, IWordFormHandler {
 			String param1 = template.getNumberedParam(0);
 			if ("er".equals(param1)) {
 				wordForms.add(createAdjectiveForm(lemma, GrammaticalDegree.POSITIVE));
-				wordForms.add(createAdjectiveForm(lemma + "er", GrammaticalDegree.COMPARATIVE));
-				wordForms.add(createAdjectiveForm(lemma + "est", GrammaticalDegree.SUPERLATIVE));
+				wordForms.add(createAdjectiveForm(removeEndingE(lemma) + "er", GrammaticalDegree.COMPARATIVE));
+				wordForms.add(createAdjectiveForm(removeEndingE(lemma) + "est", GrammaticalDegree.SUPERLATIVE));
 			} else
 			if ("-".equals(param1)) { // not comparable
 				wordForms.add(createAdjectiveForm(lemma, GrammaticalDegree.POSITIVE));
@@ -315,14 +320,14 @@ public class ENWordFormHandler implements ITemplateHandler, IWordFormHandler {
 			String param2 = template.getNumberedParam(1);
 			if ("er".equals(param2)) {
 				wordForms.add(createAdjectiveForm(lemma, GrammaticalDegree.POSITIVE));
-				wordForms.add(createAdjectiveForm(param1 + "er", GrammaticalDegree.COMPARATIVE));
-				wordForms.add(createAdjectiveForm(param1 + "est", GrammaticalDegree.SUPERLATIVE));
+				wordForms.add(createAdjectiveForm(removeEndingE(param1) + "er", GrammaticalDegree.COMPARATIVE));
+				wordForms.add(createAdjectiveForm(removeEndingE(param1) + "est", GrammaticalDegree.SUPERLATIVE));
 			} else
 			if ("er".equals(param1) && "more".equals(param2)) {
 				wordForms.add(createAdjectiveForm(lemma, GrammaticalDegree.POSITIVE));
-				wordForms.add(createAdjectiveForm(lemma + "er", GrammaticalDegree.COMPARATIVE));
+				wordForms.add(createAdjectiveForm(removeEndingE(lemma) + "er", GrammaticalDegree.COMPARATIVE));
 				wordForms.add(createAdjectiveForm("more " + lemma, GrammaticalDegree.COMPARATIVE));
-				wordForms.add(createAdjectiveForm(lemma + "est", GrammaticalDegree.SUPERLATIVE));
+				wordForms.add(createAdjectiveForm(removeEndingE(lemma) + "est", GrammaticalDegree.SUPERLATIVE));
 				wordForms.add(createAdjectiveForm("most " + lemma, GrammaticalDegree.SUPERLATIVE));
 			} else
 			if ("-".equals(param1)) { // not generally comparable
@@ -345,14 +350,14 @@ public class ENWordFormHandler implements ITemplateHandler, IWordFormHandler {
 			if ("-".equals(param1)) {
 				if ("er".equals(param3)) {
 					wordForms.add(createAdjectiveForm(lemma, GrammaticalDegree.POSITIVE));
-					wordForms.add(createAdjectiveForm(param2 + "er", GrammaticalDegree.COMPARATIVE));
-					wordForms.add(createAdjectiveForm(param2 + "est", GrammaticalDegree.SUPERLATIVE));
+					wordForms.add(createAdjectiveForm(removeEndingE(param2) + "er", GrammaticalDegree.COMPARATIVE));
+					wordForms.add(createAdjectiveForm(removeEndingE(param2) + "est", GrammaticalDegree.SUPERLATIVE));
 				} else
 				if ("er".equals(param2) && "more".equals(param3)) {
 					wordForms.add(createAdjectiveForm(lemma, GrammaticalDegree.POSITIVE));
-					wordForms.add(createAdjectiveForm(lemma + "er", GrammaticalDegree.COMPARATIVE));
+					wordForms.add(createAdjectiveForm(removeEndingE(lemma) + "er", GrammaticalDegree.COMPARATIVE));
 					wordForms.add(createAdjectiveForm("more " + lemma, GrammaticalDegree.COMPARATIVE));
-					wordForms.add(createAdjectiveForm(lemma + "est", GrammaticalDegree.SUPERLATIVE));
+					wordForms.add(createAdjectiveForm(removeEndingE(lemma) + "est", GrammaticalDegree.SUPERLATIVE));
 					wordForms.add(createAdjectiveForm("most " + lemma, GrammaticalDegree.SUPERLATIVE));
 				} else {
 					wordForms.add(createAdjectiveForm(lemma, GrammaticalDegree.POSITIVE));

--- a/src/test/java/de/tudarmstadt/ukp/jwktl/parser/en/components/ENWordFormHandlerTest.java
+++ b/src/test/java/de/tudarmstadt/ukp/jwktl/parser/en/components/ENWordFormHandlerTest.java
@@ -134,6 +134,17 @@ public class ENWordFormHandlerTest extends ENWiktionaryEntryParserTest {
 		actualIter =  handler.getWordForms().iterator();
 		assertWordFormNoun("chainmen", GrammaticalNumber.PLURAL, actualIter.next());		
 		assertFalse(actualIter.hasNext());		
+		handler = new ENWordFormHandler("carry");
+		handler.parse("{{en-noun|carr|ies}}");
+		actualIter =  handler.getWordForms().iterator();
+		assertWordFormNoun("carries", GrammaticalNumber.PLURAL, actualIter.next());		
+		assertFalse(actualIter.hasNext());
+		handler = new ENWordFormHandler("craft");
+		handler.parse("{{en-noun|~|craft|crafts}}");
+		actualIter =  handler.getWordForms().iterator();
+		assertWordFormNoun("craft", GrammaticalNumber.PLURAL, actualIter.next());
+		assertWordFormNoun("crafts", GrammaticalNumber.PLURAL, actualIter.next());		
+		assertFalse(actualIter.hasNext());
 	}
 
 	/***/
@@ -285,6 +296,42 @@ public class ENWordFormHandlerTest extends ENWiktionaryEntryParserTest {
 		assertWordFormVerb(null, null, GrammaticalTense.PRESENT, null, null, null, NonFiniteForm.PARTICIPLE, actualIter.next());
 		assertWordFormVerb("could", null, GrammaticalTense.PAST, null, null, null, null, actualIter.next());
 		assertWordFormVerb(null, null, GrammaticalTense.PAST, null, null, null, NonFiniteForm.PARTICIPLE, actualIter.next());
+		assertFalse(actualIter.hasNext());
+		handler = new ENWordFormHandler("dictionary");
+		handler.parse("{{en-verb|dictionar|ies}}");
+		actualIter = handler.getWordForms().iterator();
+		assertWordFormVerb("dictionaries", GrammaticalPerson.THIRD, GrammaticalTense.PRESENT, null, GrammaticalNumber.SINGULAR, null, null, actualIter.next());
+		assertWordFormVerb("dictionarying", null, GrammaticalTense.PRESENT, null, null, null, NonFiniteForm.PARTICIPLE, actualIter.next());
+		assertWordFormVerb("dictionaried", null, GrammaticalTense.PAST, null, null, null, null, actualIter.next());
+		assertWordFormVerb("dictionaried", null, GrammaticalTense.PAST, null, null, null, NonFiniteForm.PARTICIPLE, actualIter.next());
+		assertFalse(actualIter.hasNext());
+		handler = new ENWordFormHandler("ill");
+		handler.parse("{{en-verb|ills|illing|pres_ptc2=illin'|illed}}");
+		actualIter = handler.getWordForms().iterator();
+		assertWordFormVerb("ills", GrammaticalPerson.THIRD, GrammaticalTense.PRESENT, null, GrammaticalNumber.SINGULAR, null, null, actualIter.next());
+		assertWordFormVerb("illing", null, GrammaticalTense.PRESENT, null, null, null, NonFiniteForm.PARTICIPLE, actualIter.next());
+		assertWordFormVerb("illed", null, GrammaticalTense.PAST, null, null, null, null, actualIter.next());
+		assertWordFormVerb("illed", null, GrammaticalTense.PAST, null, null, null, NonFiniteForm.PARTICIPLE, actualIter.next());
+		assertWordFormVerb("illin'", null, GrammaticalTense.PRESENT, null, null, null, NonFiniteForm.PARTICIPLE, actualIter.next());
+		assertFalse(actualIter.hasNext());
+		handler = new ENWordFormHandler("blend");
+		handler.parse("{{en-verb|blends|blending|blended|past2=blent|past2_qual=poetic}}");
+		actualIter = handler.getWordForms().iterator();
+		assertWordFormVerb("blends", GrammaticalPerson.THIRD, GrammaticalTense.PRESENT, null, GrammaticalNumber.SINGULAR, null, null, actualIter.next());
+		assertWordFormVerb("blending", null, GrammaticalTense.PRESENT, null, null, null, NonFiniteForm.PARTICIPLE, actualIter.next());
+		assertWordFormVerb("blended", null, GrammaticalTense.PAST, null, null, null, null, actualIter.next());
+		assertWordFormVerb("blended", null, GrammaticalTense.PAST, null, null, null, NonFiniteForm.PARTICIPLE, actualIter.next());
+		assertWordFormVerb("blent", null, GrammaticalTense.PAST, null, null, null, null, actualIter.next());
+		assertWordFormVerb("blent", null, GrammaticalTense.PAST, null, null, null, NonFiniteForm.PARTICIPLE, actualIter.next());
+		assertFalse(actualIter.hasNext());
+		handler = new ENWordFormHandler("crow");
+		handler.parse("{{en-verb|crows|crowing|crowed|past2=crew|past2_qual=UK|crowed}}");
+		actualIter = handler.getWordForms().iterator();
+		assertWordFormVerb("crows", GrammaticalPerson.THIRD, GrammaticalTense.PRESENT, null, GrammaticalNumber.SINGULAR, null, null, actualIter.next());
+		assertWordFormVerb("crowing", null, GrammaticalTense.PRESENT, null, null, null, NonFiniteForm.PARTICIPLE, actualIter.next());
+		assertWordFormVerb("crowed", null, GrammaticalTense.PAST, null, null, null, null, actualIter.next());
+		assertWordFormVerb("crowed", null, GrammaticalTense.PAST, null, null, null, NonFiniteForm.PARTICIPLE, actualIter.next());
+		assertWordFormVerb("crew", null, GrammaticalTense.PAST, null, null, null, null, actualIter.next());
 		assertFalse(actualIter.hasNext());
 	}
 

--- a/src/test/java/de/tudarmstadt/ukp/jwktl/parser/en/components/ENWordFormHandlerTest.java
+++ b/src/test/java/de/tudarmstadt/ukp/jwktl/parser/en/components/ENWordFormHandlerTest.java
@@ -145,6 +145,17 @@ public class ENWordFormHandlerTest extends ENWiktionaryEntryParserTest {
 		assertWordFormNoun("craft", GrammaticalNumber.PLURAL, actualIter.next());
 		assertWordFormNoun("crafts", GrammaticalNumber.PLURAL, actualIter.next());		
 		assertFalse(actualIter.hasNext());
+		handler = new ENWordFormHandler("coral");
+		handler.parse("{{en-noun|~|}}");
+		actualIter =  handler.getWordForms().iterator();
+		assertWordFormNoun("corals", GrammaticalNumber.PLURAL, actualIter.next());
+		assertFalse(actualIter.hasNext());
+
+		handler = new ENWordFormHandler("foetus");
+		handler.parse("{{en-noun|es|}}");
+		actualIter =  handler.getWordForms().iterator();
+		assertWordFormNoun("foetuses", GrammaticalNumber.PLURAL, actualIter.next());
+		assertFalse(actualIter.hasNext());
 	}
 
 	/***/
@@ -333,6 +344,16 @@ public class ENWordFormHandlerTest extends ENWiktionaryEntryParserTest {
 		assertWordFormVerb("crowed", null, GrammaticalTense.PAST, null, null, null, NonFiniteForm.PARTICIPLE, actualIter.next());
 		assertWordFormVerb("crew", null, GrammaticalTense.PAST, null, null, null, null, actualIter.next());
 		assertFalse(actualIter.hasNext());
+
+		handler = new ENWordFormHandler("vedge");
+		handler.parse("{{en-verb||vedging|vedged}}");
+		actualIter = handler.getWordForms().iterator();
+		assertWordFormVerb("vedges", GrammaticalPerson.THIRD, GrammaticalTense.PRESENT, null, GrammaticalNumber.SINGULAR, null, null, actualIter.next());
+		assertWordFormVerb("vedging", null, GrammaticalTense.PRESENT, null, null, null, NonFiniteForm.PARTICIPLE, actualIter.next());
+		assertWordFormVerb("vedged", null, GrammaticalTense.PAST, null, null, null, null, actualIter.next());
+		assertWordFormVerb("vedged", null, GrammaticalTense.PAST, null, null, null, NonFiniteForm.PARTICIPLE, actualIter.next());
+		assertFalse(actualIter.hasNext());
+
 	}
 
 	/***/
@@ -446,6 +467,14 @@ public class ENWordFormHandlerTest extends ENWiktionaryEntryParserTest {
 		assertWordFormAdjective("free", GrammaticalDegree.POSITIVE, actualIter.next());
 		assertWordFormAdjective("freer", GrammaticalDegree.COMPARATIVE, actualIter.next());
 		assertWordFormAdjective("freest", GrammaticalDegree.SUPERLATIVE, actualIter.next());
+		assertFalse(actualIter.hasNext());
+
+		handler = new ENWordFormHandler("truncated");
+		handler.parse("{{en-adj|}}");
+		actualIter = handler.getWordForms().iterator();
+		assertWordFormAdjective("truncated", GrammaticalDegree.POSITIVE, actualIter.next());
+		assertWordFormAdjective("more truncated", GrammaticalDegree.COMPARATIVE, actualIter.next());
+		assertWordFormAdjective("most truncated", GrammaticalDegree.SUPERLATIVE, actualIter.next());
 		assertFalse(actualIter.hasNext());
 
 	}

--- a/src/test/java/de/tudarmstadt/ukp/jwktl/parser/en/components/ENWordFormHandlerTest.java
+++ b/src/test/java/de/tudarmstadt/ukp/jwktl/parser/en/components/ENWordFormHandlerTest.java
@@ -439,6 +439,15 @@ public class ENWordFormHandlerTest extends ENWiktionaryEntryParserTest {
 		assertWordFormAdjective(null, GrammaticalDegree.COMPARATIVE, actualIter.next());
 		assertWordFormAdjective(null, GrammaticalDegree.SUPERLATIVE, actualIter.next());
 		assertFalse(actualIter.hasNext());
+
+		handler = new ENWordFormHandler("free");
+		handler.parse("{{en-adj|er}}");
+		actualIter = handler.getWordForms().iterator();
+		assertWordFormAdjective("free", GrammaticalDegree.POSITIVE, actualIter.next());
+		assertWordFormAdjective("freer", GrammaticalDegree.COMPARATIVE, actualIter.next());
+		assertWordFormAdjective("freest", GrammaticalDegree.SUPERLATIVE, actualIter.next());
+		assertFalse(actualIter.hasNext());
+
 	}
 	
 	/***/


### PR DESCRIPTION
Add the missing case when parsing word forms for verb:
for example, 'dictionary' has verb like:
	{{en-verb|dictionar|ies}}
which means its forms should be:
	dictionaries, dictionarying, dictionaried, dictionaried