### PR TITLE
bugfix/#78- Remove `File:` comments, not just `Image:` comments.

### DIFF
--- a/src/main/java/de/tudarmstadt/ukp/jwktl/parser/WiktionaryEntryParser.java
+++ b/src/main/java/de/tudarmstadt/ukp/jwktl/parser/WiktionaryEntryParser.java
@@ -57,7 +57,7 @@ public abstract class WiktionaryEntryParser implements IWiktionaryEntryParser {
 	private static Logger logger = Logger.getLogger(WiktionaryEntryParser.class.getName());
 	
 	protected static final Pattern COMMENT_PATTERN = Pattern.compile("\\<!--((?!--\\>)[^\0])*?--\\>");
-	protected static final Pattern IMAGE_PATTERN = Pattern.compile("\\[\\[Image:([^\\]]+?)\\|[^\\]]+?\\]\\]");
+	protected static final Pattern IMAGE_PATTERN = Pattern.compile("\\[\\[(Image|File):([^\\]]+?)\\|[^\\]]+?\\]\\]");
 	protected static final Pattern REFERENCES_PATTERN = Pattern.compile("<ref[^>]*>.+?</ref>");
 	
 	protected ILanguage language;


### PR DESCRIPTION
This solves issue #78 (I have re-parsed a Wiktionary dump using the updated code and no longer get the issues explained in #78). 

I am assuming that `[[File` mark-up on a Wiktionary page is not used by the jwktl parser anywhere (I am not very familiar with the bulk of jwktl) - obviously if it is used elsewhere then my code change should not be approved! 

Apologies if I have not followed the correct convention for contributing to the project- I am new to this. If so, feel free to delete my pull request and make the edit yourself. 